### PR TITLE
Accept date time offsets without a colon as well

### DIFF
--- a/src/lexer.ts
+++ b/src/lexer.ts
@@ -54,7 +54,6 @@ const tokenValidPath =
 const tokenValidOperator = "abcdefghijklmnopqrstuvwxyz"
 const tokenValidNumberStart = "+-.0123456789"
 
-const tokenValidDateTime = "-0123456789T:+Z"
 const tokenValidDigits = "0123456789"
 
 const tokenTrue = "true"
@@ -170,6 +169,13 @@ class LexerContext {
 
     assertLength(length: number, error: string) {
         if (this.pos - this.start !== length) {
+            lexError(error)
+        }
+    }
+
+    assertLengthBetween(min: number, max: number, error: string) {
+        const length = this.pos - this.start
+        if (!(min <= length && length <= max)) {
             lexError(error)
         }
     }
@@ -336,24 +342,11 @@ function lexRestOfTime(ctx: LexerContext): StateFn {
 
     // offset hour
     ctx.acceptRun(tokenValidDigits)
-    ctx.assertLength(
-        26,
-        "invalid date value: " +
-            ctx.current() +
-            "; offset hour is not 2 digits long"
-    )
-    if (!ctx.accept(":")) {
-        lexError("invalid date time value: " + ctx.current())
-    }
+    ctx.accept(":")
 
     // offset minute
     ctx.acceptRun(tokenValidDigits)
-    ctx.assertLength(
-        29,
-        "invalid date value: " +
-            ctx.current() +
-            "; offset minute is not 2 digits long"
-    )
+    ctx.assertLengthBetween(28, 29, "invalid date time value: " + ctx.current())
     ctx.emit("dateTime")
 
     return lexAfterFilterValue

--- a/test/__snapshots__/lexer.test.ts.snap
+++ b/test/__snapshots__/lexer.test.ts.snap
@@ -312,6 +312,35 @@ Array [
 ]
 `;
 
+exports[`lexer should lex offset date time without colon 1`] = `
+Array [
+  Object {
+    "str": "path",
+    "type": "path",
+  },
+  Object {
+    "str": "[",
+    "type": "filtersStart",
+  },
+  Object {
+    "str": "eq",
+    "type": "filterEq",
+  },
+  Object {
+    "str": "2020-01-01T12:00:00.000+0100",
+    "type": "dateTime",
+  },
+  Object {
+    "str": "]",
+    "type": "filtersEnd",
+  },
+  Object {
+    "str": "",
+    "type": "eof",
+  },
+]
+`;
+
 exports[`lexer should lex the example correctly 1`] = `
 Array [
   Object {
@@ -484,11 +513,11 @@ exports[`lexer should not lex incomplete date time values 3`] = `"invalid date t
 
 exports[`lexer should not lex incomplete date time values 4`] = `"invalid date time value: 2020-10-10T12:12:12.123"`;
 
-exports[`lexer should not lex incomplete date time values 5`] = `"invalid date value: 2020-10-10T12:12:12.123+; offset hour is not 2 digits long"`;
+exports[`lexer should not lex incomplete date time values 5`] = `"invalid date time value: 2020-10-10T12:12:12.123+"`;
 
 exports[`lexer should not lex incomplete date time values 6`] = `"invalid date time value: 2020-10-10T12:12:12.123+12"`;
 
-exports[`lexer should not lex incomplete date time values 7`] = `"invalid date value: 2020-10-10T12:12:12.123+12:; offset minute is not 2 digits long"`;
+exports[`lexer should not lex incomplete date time values 7`] = `"invalid date time value: 2020-10-10T12:12:12.123+12:"`;
 
 exports[`lexer should not lex incomplete dates 1`] = `"invalid date value: 2020-23"`;
 

--- a/test/lexer.test.ts
+++ b/test/lexer.test.ts
@@ -97,6 +97,12 @@ describe("lexer", () => {
         expect(result).toMatchSnapshot()
     })
 
+    it("should lex offset date time without colon", () => {
+        const result = lex("path[eq:2020-01-01T12:00:00.000+0100]")
+
+        expect(result).toMatchSnapshot()
+    })
+
     it("should not lex dates with invalid formats", () => {
         expect(() => lex("path[eq:2020-1-1]")).toThrowErrorMatchingSnapshot()
     })


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.23-canary.58.f7e612a6110ab8c9e665aad631e42fe74f6c982e.0</code></summary>
  <br />
  
  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @equ-lang/parser@0.4.23-canary.58.f7e612a6110ab8c9e665aad631e42fe74f6c982e.0
  # or 
  yarn add @equ-lang/parser@0.4.23-canary.58.f7e612a6110ab8c9e665aad631e42fe74f6c982e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
